### PR TITLE
fix!: harden vSphere downloads and endpoint matching

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,13 +27,13 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.22
+    rev: v0.16.1
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.40.7
+    rev: v1.43.2
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.2.8
+    rev: v2.2.9
     hooks:
       - id: build-docs
         language: python

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 -------- | -------- | ---- | -----------
 **server** | required | string | Server IP/Hostname |
 **verify_server_cert** | optional | boolean | Verify server certificate |
+**max_download_size_mb** | optional | numeric | Maximum datastore file download size in MiB |
 **username** | required | string | Administrator username |
 **password** | required | password | Administrator password |
 

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * Fixed large vSphere datastore downloads to use an integer stream chunk size.
+* Bound vSphere datastore downloads to a configurable 300 MiB default and cleaned up incomplete vault staging files.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -2,3 +2,4 @@
 
 * Fixed large vSphere datastore downloads to use an integer stream chunk size.
 * Bound vSphere datastore downloads to a configurable 300 MiB default and cleaned up incomplete vault staging files.
+* Updated get system info to match hostnames without case sensitivity and search every guest NIC address.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Fixed large vSphere datastore downloads to use an integer stream chunk size.

--- a/vsphere.json
+++ b/vsphere.json
@@ -34,15 +34,22 @@
             "required": false,
             "default": true
         },
+        "max_download_size_mb": {
+            "data_type": "numeric",
+            "order": 2,
+            "description": "Maximum datastore file download size in MiB",
+            "required": false,
+            "default": 300
+        },
         "username": {
             "data_type": "string",
-            "order": 2,
+            "order": 3,
             "description": "Administrator username",
             "required": true
         },
         "password": {
             "data_type": "password",
-            "order": 3,
+            "order": 4,
             "description": "Administrator password",
             "required": true
         }

--- a/vsphere_connector.py
+++ b/vsphere_connector.py
@@ -15,6 +15,7 @@
 #
 #
 # Phantom imports
+import ipaddress
 import os
 import re
 import shutil
@@ -117,6 +118,38 @@ class VsphereConnector(BaseConnector):
         "config.guestFullName",
         "runtime.powerState",
     ]
+
+    @staticmethod
+    def _normalize_endpoint(value):
+        if value is None:
+            return None
+
+        value = str(value).strip()
+        if not value:
+            return None
+
+        try:
+            return ipaddress.ip_address(value)
+        except ValueError:
+            return value.casefold()
+
+    @classmethod
+    def _matches_endpoint(cls, queried_endpoint, vm):
+        queried_endpoint = cls._normalize_endpoint(queried_endpoint)
+        if queried_endpoint is None:
+            return False
+
+        candidates = {
+            cls._normalize_endpoint(vm.get("guest.ipAddress")),
+            cls._normalize_endpoint(vm.get("guest.hostName")),
+        }
+        for nic in vm.get("guest.net") or []:
+            candidates.update(cls._normalize_endpoint(address) for address in (getattr(nic, "ipAddress", None) or []))
+            ip_config = getattr(nic, "ipConfig", None)
+            candidates.update(cls._normalize_endpoint(address.ipAddress) for address in (getattr(ip_config, "ipAddress", None) or []))
+
+        candidates.discard(None)
+        return queried_endpoint in candidates
 
     def _collect_vm_properties(self, properties=None):
         """Paginated bulk property fetch. Returns list of dicts keyed by property path."""
@@ -307,7 +340,7 @@ class VsphereConnector(BaseConnector):
         action_result = self.add_action_result(ActionResult(dict(param)))
 
         ip_hostname = param[VSPHERE_JSON_IP_HOSTNAME]
-        all_vms = self._collect_vm_properties()
+        all_vms = self._collect_vm_properties([*self._VM_PROPERTIES, "guest.net"])
         total_vms = len(all_vms)
         matched = False
 
@@ -315,7 +348,7 @@ class VsphereConnector(BaseConnector):
             ip = vm.get("guest.ipAddress")
             hostname = vm.get("guest.hostName")
 
-            if (ip_hostname != ip) and (ip_hostname != hostname):
+            if not self._matches_endpoint(ip_hostname, vm):
                 continue
 
             curr_data = action_result.add_data({})

--- a/vsphere_connector.py
+++ b/vsphere_connector.py
@@ -613,7 +613,7 @@ class VsphereConnector(BaseConnector):
 
         # if the file is big then download in % increments
         if bytes_to_download > big_file_size_bytes:
-            block_size = (bytes_to_download * percent_block) / 100
+            block_size = (bytes_to_download * percent_block) // 100
 
         bytes_downloaded = 0
 

--- a/vsphere_connector.py
+++ b/vsphere_connector.py
@@ -17,6 +17,7 @@
 # Phantom imports
 import os
 import re
+import shutil
 import ssl
 import time
 from collections import defaultdict
@@ -53,11 +54,20 @@ class VsphereConnector(BaseConnector):
 
         self._vs_server = None
         self._verify = True
+        self._max_download_size_bytes = VSPHERE_DEFAULT_MAX_DOWNLOAD_SIZE_MB * 1024 * 1024
 
     def initialize(self):
         config = self.get_config()
 
         self._verify = config.get("verify_server_cert", True)
+
+        try:
+            max_download_size_mb = int(config.get(VSPHERE_JSON_MAX_DOWNLOAD_SIZE_MB, VSPHERE_DEFAULT_MAX_DOWNLOAD_SIZE_MB))
+            if max_download_size_mb <= 0:
+                raise ValueError
+        except (TypeError, ValueError):
+            return self.set_status(phantom.APP_ERROR, VSPHERE_ERR_INVALID_MAX_DOWNLOAD_SIZE)
+        self._max_download_size_bytes = max_download_size_mb * 1024 * 1024
 
         # setup the auth
         self._auth = HTTPBasicAuth(config[phantom.APP_JSON_USERNAME], config[phantom.APP_JSON_PASSWORD])
@@ -602,6 +612,20 @@ class VsphereConnector(BaseConnector):
         if bytes_to_download <= 0:
             return (action_result.set_status(phantom.APP_ERROR, VSPHERE_ERR_EMPTY_FILE), content_size)
 
+        if r.headers.get("transfer-encoding"):
+            return (action_result.set_status(phantom.APP_ERROR, VSPHERE_ERR_TRANSFER_ENCODED_DOWNLOAD), content_size)
+
+        if bytes_to_download > self._max_download_size_bytes:
+            return (
+                action_result.set_status(
+                    phantom.APP_ERROR,
+                    VSPHERE_ERR_DOWNLOAD_TOO_LARGE,
+                    declared=bytes_to_download,
+                    maximum=self._max_download_size_bytes,
+                ),
+                content_size,
+            )
+
         content_type = r.headers.get("content-type", "").lower()
         if expect_binary and content_type.startswith("text/"):
             return (action_result.set_status(phantom.APP_ERROR, VSPHERE_ERR_TEXT_CONTENT_TYPE), content_size)
@@ -616,23 +640,43 @@ class VsphereConnector(BaseConnector):
             block_size = (bytes_to_download * percent_block) // 100
 
         bytes_downloaded = 0
+        download_limit_error = None
 
         try:
             with open(local_file_path, "wb") as file_handle:
                 for chunk in r.iter_content(chunk_size=block_size):
                     if chunk:
                         bytes_downloaded += len(chunk)
+                        if bytes_downloaded > bytes_to_download or bytes_downloaded > self._max_download_size_bytes:
+                            download_limit_error = VSPHERE_ERR_FILE_SIZE_MISMATCH
+                            break
                         file_handle.write(chunk)
                         file_handle.flush()
                         os.fsync(file_handle.fileno())
                         self.send_progress(VSPHERE_PROG_FINISHED_DOWNLOADING_STATUS, float(bytes_downloaded) / float(bytes_to_download))
         except Exception as e:
+            self._remove_local_file(local_file_path)
             return (action_result.set_status(phantom.APP_ERROR, VSPHERE_ERR_SERVER_CONNECTION, e), content_size)
 
-        if bytes_downloaded != bytes_to_download:
+        if download_limit_error or bytes_downloaded != bytes_to_download:
+            self._remove_local_file(local_file_path)
             return (action_result.set_status(phantom.APP_ERROR, VSPHERE_ERR_FILE_SIZE_MISMATCH), bytes_downloaded)
 
         return (action_result.set_status(phantom.APP_SUCCESS, phantom.APP_SUCC_FILE_DOWNLOAD), bytes_downloaded)
+
+    def _remove_local_file(self, local_file_path):
+        try:
+            os.remove(local_file_path)
+        except FileNotFoundError:
+            pass
+        except OSError as e:
+            self.debug_print("Unable to remove partial download", e)
+
+    def _remove_temp_dir(self, temp_dir):
+        try:
+            shutil.rmtree(temp_dir)
+        except OSError as e:
+            self.debug_print("Unable to remove temporary download directory", e)
 
     def _parse_snap_list_file(self, local_file_path, snap_name, id):
         """Function that parses the snapshot list file from a local location and return the file name
@@ -751,16 +795,19 @@ class VsphereConnector(BaseConnector):
         status_code, content_size = self._download_file(snap_list_url, action_result, local_file_path)
 
         if phantom.is_fail(status_code):
+            self._remove_temp_dir(temp_dir)
             return action_result.get_status()
 
         # parse the downloaded file and get the file_name that our snapshot represents
         snap_file = self._parse_snap_list_file(local_file_path, snap_name, id)
         if not snap_file:
+            self._remove_temp_dir(temp_dir)
             return action_result.set_status(phantom.APP_ERROR, VSPHERE_ERR_SNAPSHOT_PATH, snap_name)
 
         # got the file name, now get the url of this file_name
         snap_file_url = self._create_url_of_file(server, "snapshotData", vm, datacenter, snap_file)
         if not snap_file_url:
+            self._remove_temp_dir(temp_dir)
             return action_result.set_status(phantom.APP_ERROR, VSPHERE_ERR_SNAPSHOT_URL, snap_name)
 
         # Set the status to failure, this is to override the successful download status of the snapshot list file
@@ -773,6 +820,7 @@ class VsphereConnector(BaseConnector):
         self.save_progress(VSPHERE_PROG_SNAPSHOT_DOWNLOADING, snap_name=snap_name)
         status_code, content_size = self._download_file(snap_file_url, action_result, local_file_path, expect_binary=True)
         if phantom.is_fail(status_code):
+            self._remove_temp_dir(temp_dir)
             return action_result.get_status()
 
         # move it to the vault
@@ -790,10 +838,7 @@ class VsphereConnector(BaseConnector):
 
         # remove the temp folder
         finally:
-            try:
-                os.rmdir(temp_dir)
-            except Exception as e:
-                self.debug_print("Handled exception", e)
+            self._remove_temp_dir(temp_dir)
         return action_result.get_status()
 
     def _download_suspend_file(self, vmx_path, config, action_result, vm, container_id, datacenter):
@@ -835,6 +880,7 @@ class VsphereConnector(BaseConnector):
         status_code, content_size = self._download_file(vm_suspend_url, action_result, local_file_path, expect_binary=True)
 
         if phantom.is_fail(status_code):
+            self._remove_temp_dir(temp_dir)
             return action_result.get_status()
 
         # move it to the vault
@@ -850,11 +896,7 @@ class VsphereConnector(BaseConnector):
                 ["os memory dump", VSPHERE_CONST_SUSPEND_FILE_TYPE],
             )
         finally:
-            try:
-                # remove the temp folder
-                os.rmdir(temp_dir)
-            except Exception as e:
-                self.debug_print("Handled exception", e)
+            self._remove_temp_dir(temp_dir)
         return action_result.get_status()
 
     def _get_latest_snapshot_info(self, vm):

--- a/vsphere_consts.py
+++ b/vsphere_consts.py
@@ -24,6 +24,7 @@ VSPHERE_JSON_DISPLAY_NAME = "display_name"
 VSPHERE_JSON_GUEST_HOST_NAME = "vm_hostname"
 VSPHERE_JSON_SNAP_NAME = "snapshot"
 VSPHERE_JSON_IP_HOSTNAME = "ip_hostname"
+VSPHERE_JSON_MAX_DOWNLOAD_SIZE_MB = "max_download_size_mb"
 
 # Status messages for vsphere app
 VSPHERE_ERR_SERVER_CONNECT = "Connection to {server_ip} failed"
@@ -36,6 +37,9 @@ VSPHERE_ERR_INVALID_CONTENT_LENGTH = "Server returned an invalid content length"
 VSPHERE_ERR_EMPTY_FILE = "Server returned an empty file"
 VSPHERE_ERR_TEXT_CONTENT_TYPE = "Server returned text content instead of a datastore file"
 VSPHERE_ERR_FILE_SIZE_MISMATCH = "Downloaded file size did not match the server response"
+VSPHERE_ERR_TRANSFER_ENCODED_DOWNLOAD = "Server returned an unsupported transfer-encoded datastore file"
+VSPHERE_ERR_DOWNLOAD_TOO_LARGE = "Declared file size {declared} bytes exceeds the maximum download size {maximum} bytes"
+VSPHERE_ERR_INVALID_MAX_DOWNLOAD_SIZE = "Maximum download size must be a positive number of MiB"
 VSPHERE_ERR_CANNOT_FIND_SUSPEND_FILE = "Unable to locate suspend file"
 VSPHERE_ERR_SNAPSHOT_URL = "Could not create url to file for snapshot '{}'"
 VSPHERE_ERR_VM_FROM_VMX_PATH = "Could not get vm object from the vmx path"
@@ -78,6 +82,7 @@ VSPHERE_CONST_DEFAULT_DATACENTER = "ha-datacenter"
 VSPHERE_CONST_URL = "url"
 VSPHERE_CONST_DATACENTER = "dcPath"
 VSPHERE_CONST_DATASTORE = "dsName"
+VSPHERE_DEFAULT_MAX_DOWNLOAD_SIZE_MB = 300
 
 # This text is compared with an error that we get from the vsphere server, don't change
 # If you need to change this, then change this value to a list and add the newer string to it.


### PR DESCRIPTION
Written by Codex.

### Bug Fixes

- PSAAS-34153 (VULN-101677, FS-7661): use an integer stream chunk size for datastore files larger than 20 MiB; the missing Content-Length path was already handled by merged PR #30.
- PSAAS-33042 (VULN-96453, FS-4842): enforce a configurable 300 MiB default before and during datastore downloads, reject ambiguous transfer-encoded responses, and remove incomplete vault staging files and directories.
- PSAAS-34300 (VULN-101824, FS-7808): normalize IP representations, compare hostnames without case sensitivity, and inspect every address exposed through both current and legacy guest NIC fields.

### Manual Documentation

<details><summary>
Have you made any changes that should be documented in manual_readme_content.md?
</summary><br />

The generated README now documents the new optional max_download_size_mb asset setting. This connector has no additional manual documentation change for the existing actions.
</details>

- [x] I have verified that manual documentation has been updated where appropriate

### Tracking

- Epic: ESPM-5228
- PAPP: PAPP-38307
- PSAAS: PSAAS-33042, PSAAS-34153, PSAAS-34300
- Provenance: VULN-96453 / FS-4842, VULN-101677 / FS-7661, VULN-101824 / FS-7808

### Sources And Patch Decisions

- Splunk documents a 300 MB vault upload limit: https://help.splunk.com/?resourceId=SOAR_PlaybookAPI_VaultAPI
- RFC 9112 defines Transfer-Encoding as overriding Content-Length: https://www.rfc-editor.org/rfc/rfc9112#section-6.3
- Requests documents iter_content chunk_size as an integer: https://requests.readthedocs.io/en/stable/api/#requests.Response.iter_content
- Broadcom documents guest.ipAddress as the primary address and guest.net as the per-NIC collection: https://developer.broadcom.com/xapis/vsphere-web-services-api/latest/vim.vm.GuestInfo.html
- Broadcom documents GuestNicInfo.ipAddress and the current ipConfig structure: https://developer.broadcom.com/xapis/vsphere-web-services-api/latest/vim.vm.GuestInfo.NicInfo.html
- The PSAAS-33042 patch's arbitrary 10 GiB constant was replaced with a configurable, documented 300 MiB default and complete failure-path cleanup.
- The PSAAS-34300 patch was adapted to pyVmomi's current and legacy address objects; ambiguous short-hostname matching was not added.

### Verification

- pre-commit run --all-files passed every applicable hook, including Docker-backed dependency packaging, build docs, notice generation, and static tests.
- python3 -m py_compile vsphere_connector.py vsphere_consts.py passed.
- jq empty vsphere.json and git diff --check origin/main..HEAD passed.
- Commit bodies were checked for real paragraph breaks, Codex attribution, and a parseable BREAKING CHANGE trailer.
- This is a BaseConnector app, so no connector-local pytest scaffolding was added.
- Integration and sanity tests are deferred to hosted CI.

### Compatibility

The new max_download_size_mb asset field defaults to 300 MiB. This is a breaking secure-default change because larger datastore downloads that previously reached the vault-add stage now stop during streaming; operators can configure another positive bounded value.

### Other information

- Existing unrelated pyVmomi migration PR #25 is not modified.
- Merge strategy: merge commit only; do not squash

---
Please refer to our [Contribution Guide](https://github.com/splunk-soar-connectors/.github/blob/main/.github/CONTRIBUTING.md) for any questions on submitting a pull request.

Thanks for contributing!
